### PR TITLE
Use https protocol to fetch fonts on google

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 @import url(
-	http://fonts.googleapis.com/css?family=Lato:400,700
+	https://fonts.googleapis.com/css?family=Lato:400,700
 );
 body {
 	background: #fff;


### PR DESCRIPTION
Using protocol-relative URL will be even better, but can't work locally, so I think we can use https here, can also improve the security and prevent the warning on browsers' console.
